### PR TITLE
Added markers for sources with gaia XP spectra

### DIFF
--- a/hcam_finder/finders.py
+++ b/hcam_finder/finders.py
@@ -650,6 +650,10 @@ class FovSetter(tk.LabelFrame):
                 self.logger.error(msg=errmsg)
                 self.fitsimage.onscreen_message(errmsg)
             else:
+                current_tags = self.canvas.get_tags()
+                for current_tag in current_tags:
+                    if current_tag.isdigit():
+                        self.canvas.delete_object_by_tag(current_tag)
                 self.draw_ccd()
                 self.targetMarker()
             finally:


### PR DESCRIPTION
I've been thinking that some of the issues we have with flux calibration (mainly with HiPERCAM where you're lucky if there's a flux standard observed in the same night) may be helped by having comparison stars with Gaia XP spectra that can be used for synthetic photometry within the same field and therefore removing issues with related to having to fit the atmospheric extinction too.
I plan to add XP spectra calibration to my cam_cal package at some point in the future once I work out how to properly use the XP spectra i.e. standardising them and testing the u-band stuff (and find the time). For now though I thought it would be good to be able to know when planning observations what comparison stars at least _have_ XP spectra. I've therefore added red markers around sources that have Gaia XP spectra within a given radius from the target in the finding chart tools.
Code is probably not as good as it could be but it seems to run fine on my system. Let me know what you think

Alex