### PR TITLE
fix incorrect JSON TARG_RA for decimal coords

### DIFF
--- a/hcam_finder/hcam_finder.py
+++ b/hcam_finder/hcam_finder.py
@@ -77,7 +77,10 @@ class HCAMFovSetter(FovSetter):
         # target info
         target = dict()
         target["target"] = self.targName.value()
-        targ_coord = SkyCoord(self.targCoords.value(), unit=(u.hour, u.deg))
+        if self.have_decimal_coords():
+            targ_coord = SkyCoord(self.targCoords.value(), unit=(u.deg, u.deg))
+        else:
+            targ_coord = SkyCoord(self.targCoords.value(), unit=(u.hourangle, u.deg))
         target["TARG_RA"] = targ_coord.ra.to_string(
             sep=":", unit=u.hour, pad=True, precision=2
         )

--- a/hcam_finder/hcam_finder.py
+++ b/hcam_finder/hcam_finder.py
@@ -80,7 +80,7 @@ class HCAMFovSetter(FovSetter):
         if self.have_decimal_coords():
             targ_coord = SkyCoord(self.targCoords.value(), unit=(u.deg, u.deg))
         else:
-            targ_coord = SkyCoord(self.targCoords.value(), unit=(u.hourangle, u.deg))
+            targ_coord = SkyCoord(self.targCoords.value(), unit=(u.hour, u.deg))
         target["TARG_RA"] = targ_coord.ra.to_string(
             sep=":", unit=u.hour, pad=True, precision=2
         )


### PR DESCRIPTION
I've noticed that when decimal coordinates are given, the TARG_RA in the JSON file is incorrect as no unit check is carried out and so it just assumes hourangle units. I don't know if much depends on the TARG_RA field in the JSON files but it's an easy fix